### PR TITLE
Demo 2.5 fix

### DIFF
--- a/themes/TabTheme/widgets/SidebarController/Widget.html
+++ b/themes/TabTheme/widgets/SidebarController/Widget.html
@@ -3,7 +3,7 @@
     
   </div>
   <div class="max-pane" data-dojo-attach-point="maxStateNode">
-    <div class="title-list" data-dojo-attach-point="titleListNode"></div>
+    <div id='data_icons' class="title-list" data-dojo-attach-point="titleListNode"></div>
     <div class="content-list" data-dojo-attach-point="contentListNode"></div>
   </div>
   <div class="other-group-pane" data-dojo-attach-point="otherGroupNode"></div>

--- a/themes/TabTheme/widgets/SidebarController/Widget.js
+++ b/themes/TabTheme/widgets/SidebarController/Widget.js
@@ -710,6 +710,7 @@ define([
             title: title,
             'class': 'title-node jimu-float-leading',// jimu-leading-margin15',
             'settingid': config.id,
+            'id': config.id,
             i: this.tabs.length,
             style: {
               width: nodeWidth + 'px'
@@ -734,6 +735,7 @@ define([
             title: title,
             'class': 'title-node',
             'settingid': config.id,
+            'id': config.id + '_min',
             i: this.tabs.length
           }, this.minStateNode),
 

--- a/widgets/BoundaryLayer/Widget.html
+++ b/widgets/BoundaryLayer/Widget.html
@@ -8,7 +8,7 @@
     </div-->
 
     <div id="tableBoundaryLayersArea" dojotype="dijit.layout.ContentPane" style="height: calc(100% - 20px);height: -moz-calc(100% - 20px); height: -webkit-calc(100% - 20px);">
-        <table id="tableBoundaryLayers"  >
+        <table id="tableBoundaryLayers" style="width: 100%" >
             <tbody>
                 <tr>
 

--- a/widgets/Demo/Widget.js
+++ b/widgets/Demo/Widget.js
@@ -30,29 +30,7 @@ function(declare, BaseWidget, PanelManager, TooltipDialog, Button, popup, Accord
         activeContainer = null;
         this.fetchData();
 
-      //this.mapIdNode.innerHTML = 'map id:' + this.map.id;
-
-      //Add Help content
-      /*aContainer = new AccordionContainer({style:"height: 300px"}, this.helptopics);
-      aContainer.addChild(new ContentPane({
-        title: "Simple Search Filter",
-        content: "Simple Search Filter Help stuff"
-      }));
-      aContainer.addChild(new ContentPane({
-        id: "Addfile",
-        title:"Upload Data Widget",
-        content:"Put lots of Help Content here!"
-      }));
-      aContainer.addChild(new ContentPane({
-        id: "eBasemapGallery",
-        title:"Basemap Gallery",
-        content:"Help Documentation for Basemap Widget"
-      }));
-      aContainer.startup();
-
-      if(activeContainer){
-        aContainer.selectChild( activeContainer );
-      }*/
+      
 
       //Tour setup
       helpTour = this.config.tour; //tour info from config.json file
@@ -83,10 +61,14 @@ function(declare, BaseWidget, PanelManager, TooltipDialog, Button, popup, Accord
     _startTour: function(){
 
         
-        //$('#overlay').css('z-index', '1000');
-        var overlay = dojo.create('div', {
+        var overlay1 = dojo.create('div', {
           "class": "overlay",
           "id": "overlay"
+        }, dojo.byId('main-page'));
+
+        var overlay2 = dojo.create('div', {
+          "class": "overlay2",
+          "id": "overlay2"
         }, dojo.byId('main-page'));
 
         //Close the tour main widget
@@ -109,7 +91,7 @@ function(declare, BaseWidget, PanelManager, TooltipDialog, Button, popup, Accord
             $('#'+helpTour[i].highlight).css('z-index', '');
           }
         if (helpTour[stop].highlight) {
-          $('#'+helpTour[stop].highlight).css('z-index', '1000');
+          $('#'+helpTour[stop].highlight).css('z-index', '998');
         } 
 
 
@@ -179,6 +161,7 @@ function(declare, BaseWidget, PanelManager, TooltipDialog, Button, popup, Accord
     _endTour: function(){
         popup.close(tourDialog);
         dojo.destroy("overlay");
+        dojo.destroy("overlay2");
         
         for (i=0; i<numberStops; i++) {
             $('#'+helpTour[i].highlight).css('z-index', '');

--- a/widgets/Demo/config.json
+++ b/widgets/Demo/config.json
@@ -18,7 +18,7 @@
 					"</ul>",
 					"</p>"],
 		"orient": ["below","below-alt", "above", "above-alt"],
-		"highlight": "themes_TabTheme_widgets_SidebarController_Widget_20"
+		"highlight": "data_icons"
 	},{
 		"node":"dijit_TitlePane_0",
 		"content": ["<h1>Data</h1>",
@@ -55,7 +55,7 @@
 	},{
 		"node":"dijit__WidgetBase_1",
 		"content": ["<h1>Community Selection Widget</h1>",
-					"<p>Your selection changes the legend when using community data layers.</p>",
+					"<p>Your selection changes the legend for community data layers.</p>",
 					"<ul>",
 					"<li>Use \"Combined Communities\" to have a comparable legend across ",
 					"multiple communities</li>",
@@ -66,42 +66,41 @@
 	},{
 		"node":"dijit__WidgetBase_2",
 		"content": ["<h1>Mapping Tools</h1>",
-					"<p>Find mapping tools here:</p>",
 					"<ul>",
 					"<li>Set bookmarks</li>",
 					"<li>Print</li>",
 					"<li>Draw and measure",
 					"<li>Open legend</li>",
+					"<li>Add external data</li>",
 					"</ul>"],
 		"orient": ["below","below-alt", "above", "above-alt"],
 		"highlight": "dijit__WidgetBase_2"
 	},{
-		"node":"dijit__WidgetBase_6",
+		"node":"dijit__WidgetBase_10",
 		"content": ["<h1>Analytical Tools</h1>",
-					"<p>You can find analysis tools here such as:</p>",
 					"<ul>",
 					"<li>Change Analysis Tool</li>",
 					"<li>Raindrop</li>",
 					"<li>Elevation Profile</li>",
+					"<li>HUC Navigator</li>",
 					"</ul>"],
 		"orient": ["below","below-alt", "above", "above-alt"],
-		"highlight": "dijit__WidgetBase_6"
-	},{
-		"node":"dijit__WidgetBase_12",
-		"content": ["<h1>Map Tools</h1>",
-					"<p>Here you will find tools to add additional data to your map.</p>",
-					"<ul>",
-					"<li>Upload a shapefile</li>",
-					"<li>Add a web service</li>",
-					"</ul>"],
-		"orient": ["below","below-alt", "above", "above-alt"],
-		"highlight": "dijit__WidgetBase_12"
+		"highlight": "dijit__WidgetBase_10"
 	},{
 		"node":"dijit__WidgetBase_16",
+		"content": ["<h1>Save Session</h1>",
+					"<ul>",
+					"<li>Save your progress</li>",
+					"<li>Share your sessions with other users</li>",
+					"</ul>"],
+		"orient": ["below","below-alt", "above", "above-alt"],
+		"highlight": "dijit__WidgetBase_16"
+	},{
+		"node":"dijit__WidgetBase_17",
 		"content": ["<h1>Tour</h1>",
 					"<p>Access the in-depth EnviroAtlas User Guide or restart ",
 					"this tour.<br><br></p>"],
 		"orient": ["below","below-alt", "above", "above-alt"],
-		"highlight": "dijit__WidgetBase_16"
+		"highlight": "dijit__WidgetBase_17"
 	}]
 }

--- a/widgets/Demo/css/style.css
+++ b/widgets/Demo/css/style.css
@@ -42,7 +42,18 @@ cursor: pointer;
 
 
 .overlay {
-	opacity:0.8; 
+	opacity:0.7; 
+	background-color:#000; 
+	position:fixed; 
+	width:100%; 
+	height:100%; 
+	top:0px; 
+	left:0px; 
+	z-index:997
+}
+
+.overlay2 {
+	opacity:0.1; 
 	background-color:#000; 
 	position:fixed; 
 	width:100%; 


### PR DESCRIPTION
Fixed the highlighting for the tour.  The sidebar was missing an ID field that I used previously to attach the popup.  

I also restricted the user from being able to interact with the highlighted widgets.  Originally, the highlighting was done by overlaying the entire window with a transparent div and then adjusting the z-value of the highlighted div above the overlay.  I kept that same workflow but I added an additional div over the entire window.  The 2nd overlay has a low opacity (nearly transparent) and is above any highlighted div but below the demo popup. 

There may be an easier way to do this, but it is working.  Once the demo starts the user can only interact with the demo popup.  