### PR TITLE
Switch to CSS for handling cell spacing.

### DIFF
--- a/widgets/LayerList/LayerListView.js
+++ b/widgets/LayerList/LayerListView.js
@@ -185,9 +185,8 @@ define([
       // set tdNode width
       domStyle.set(layerTdNode, 'width', level * 12 + 40 + 'px');
 
-
       scaleLabel = domConstruct.create('td', {
-        'style': 'width:22px; vertical-align:top'
+        'class': 'col col15'
       }, layerTrNode);
 
 

--- a/widgets/LayerList/css/style.css
+++ b/widgets/LayerList/css/style.css
@@ -82,6 +82,15 @@
   vertical-align: top;
 }
 
+.jimu-widget-layerList .col15{
+  vertical-align: top;
+  width: 22px;
+}
+
+.jimu-widget-layerList .layer-sub-node .col15{
+  width: 0px;
+}
+
 .jimu-widget-layerList .col2{
   width: auto;
   word-break: break-word;


### PR DESCRIPTION
Still leaves a gap at the top level, but handles sublevels.  