### PR TITLE
Remove global overflow style - seemed unused in hucnav, spilled over …

### DIFF
--- a/widgets/NavHuc/css/style.css
+++ b/widgets/NavHuc/css/style.css
@@ -1725,7 +1725,7 @@ h3 {
     margin-right: 15px;
 }
 
-.dijitContentPane {
+/*.dijitContentPane {
   overflow: hidden !important;
-}
+}*/
 


### PR DESCRIPTION
…into other widgets

The whole hucnav style.css file is a mess of global styles.  