### PR TITLE
link demographic service queries to web service in the layer list

### DIFF
--- a/widgets/LayerList/PopupMenuInfo.js
+++ b/widgets/LayerList/PopupMenuInfo.js
@@ -246,14 +246,15 @@ define([
         if (((layerId.indexOf(window.layerIdPrefix)) >= 0)||(bFeaturedCollection == true)) {
 			arrXmlPath.push("widgets/SimpleSearchFilter/config_layer.json");
 			getInfoFromJsonWithEaID(getInfoWithEaID, arrXmlPath, eaID, actionType);
-        }     
-        else if (eaID==window.timeSeriesLayerId) {
-    		var climateVar = document.getElementById("climateSelection").value;
-        	metaDataIDFromVariable = window.timeSeriesMetadata[climateVar];
-        	metaDataID = window.nationalMetadataDic[metaDataIDFromVariable];
-            window.open(window.matadata + "?uuid=%7B" + metaDataID + "%7D");	       	
-        }   
-        else {
+        } else if (eaID==window.timeSeriesLayerId) {
+          var climateVar = document.getElementById("climateSelection").value;
+          metaDataIDFromVariable = window.timeSeriesMetadata[climateVar];
+          metaDataID = window.nationalMetadataDic[metaDataIDFromVariable];
+           window.open(window.matadata + "?uuid=%7B" + metaDataID + "%7D");	       	
+        } // open demographics url if added from Demographic Layers widget
+          else if (layerId.includes('ejdemog') || layerId.includes('census2010') || layerId.includes('census2000')) {
+          window.open('https://www.epa.gov/ejscreen/ejscreen-map-descriptions');
+        } else {
         	arrXmlPath.push("widgets/SimpleSearchFilter/config_layer.json");  	
         	getInfoFromJsonWithEaID(getInfoWithEaID, arrXmlPath, clickedURL, actionType);
         }    	


### PR DESCRIPTION
Add logic to link to metadata/info for demographic layers added to layer list. When "Access Web Service" is selected in the layer list, all demographic layers are linked to an EPA info site for EJ Screen.