### PR TITLE
Add metadata link for 2000 Census layers

### DIFF
--- a/widgets/LayerList/PopupMenuInfo.js
+++ b/widgets/LayerList/PopupMenuInfo.js
@@ -252,7 +252,7 @@ define([
           metaDataID = window.nationalMetadataDic[metaDataIDFromVariable];
            window.open(window.matadata + "?uuid=%7B" + metaDataID + "%7D");	       	
         } // open demographics url if added from Demographic Layers widget
-          else if (layerId.includes('ejdemog') || layerId.includes('census2010') || layerId.includes('census2000')) {
+          else if (layerId.includes('ejdemog') || layerId.includes('census2010') || layerId.includes('census2000') || layerId.includes('census2k')) {
           window.open('https://www.epa.gov/ejscreen/ejscreen-map-descriptions');
         } else {
         	arrXmlPath.push("widgets/SimpleSearchFilter/config_layer.json");  	


### PR DESCRIPTION
Megan Culler reviewed the apps demographic layers metadata/access web service links - "The metadata link worked for every layer I checked except for Education Less Than High School (2000 Census)." This pull request adds logic for the 2000 Census layers that contain a layer id with "census2k".