### PR TITLE
Michigan is missing at the state scale for Pct Land and Pct Water for 2010 Census

### DIFF
--- a/widgets/DemographicLayers/Widget.js
+++ b/widgets/DemographicLayers/Widget.js
@@ -309,8 +309,8 @@ createCategory: function (key) {
                         layerJson[colname].tr_max = trmax;
                         layerJson[colname].cnty_min = cntymin;
                         layerJson[colname].cnty_max = cntymax;
-                        layerJson[colname].st_min = stmin;
-                        layerJson[colname].st_max = stmax;
+                        layerJson[colname].st_min = stmin - .01;
+                        layerJson[colname].st_max = stmax + .01;
 
                         if (typeof featset.features[m].attributes["BLK_MIN"] != 'undefined') {
                             var blkmin = featset.features[m].attributes["BLK_MIN"];


### PR DESCRIPTION
Adjust the min and max for state census data queries to include the missing data points in the symbology. The legend shows the data range as a whole number, so this minor edit doesn't change the legend data range.