### PR TITLE
Remove Census Block Groups from option list in staging.

### DIFF
--- a/widgets/GriddedMapTool/Widget.html
+++ b/widgets/GriddedMapTool/Widget.html
@@ -81,7 +81,7 @@
             <option value="county">County</option>
             <!--<option value="state">State</option>-->
             <option value="district">Congressional District</option>
-            <option value="blockgroup">Census Block Group</option>
+            <!-- <option value="blockgroup">Census Block Group</option> -->
             <option value="huc-8">Subbasin (HUC-8)</option>
             <option value="huc-12">Subwatershed (HUC-12)</option>
             <option value="point">Draw a point</option>


### PR DESCRIPTION
Comment out the option for Census Block Groups from html. For staging only.