### PR TITLE
Raindrop tool warning message.

### DIFF
--- a/widgets/Raindrop/Widget.html
+++ b/widgets/Raindrop/Widget.html
@@ -15,6 +15,8 @@
 						<br><br>
 					</p>
 					<a target = "_blank" href="https://www.epa.gov/enviroatlas/tutorials">Learn more in our applicaton.</a>
+						<br></br>
+					<p><i>The Raindrop tool uses a service which is currently not functioning. EnviroAtlas is working to get the tool functioning as soon as possible.</i></p>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
Request to put an outage alert on the raindrop tool which calls waters api and returns 555 error.